### PR TITLE
Update id-authentication-env.properties

### DIFF
--- a/config-templates/id-authentication-env.properties
+++ b/config-templates/id-authentication-env.properties
@@ -100,7 +100,11 @@ mosip.authentication.salt-generator.chunk-size=10
 #---------------------------------kernel Salt Generator---------------------------------------------------#
 mosip.kernel.salt-generator.db.key-alias=javax.persistence.jdbc
 mosip.kernel.salt-generator.schemaName=${javax.persistence.jdbc.schema}
-#----------------------------------------------------------------------------------------------------------#
+#--------------------------------TokenId generator---------------------------------------------------#
+mosip.kernel.tokenid.uin.salt=zHuDEAbmbxiUbUShgy6pwUhKh9DE0EZn9kQDKPPKbWscGajMwf
+mosip.kernel.tokenid.partnercode.salt=yS8w5Wb6vhIKdf1msi4LYTJks7mqkbmITk2O63Iq8h0bkRlD0d
+#----------------------------------------------------------------------------------------------------#
+
 
 # *********** REST-services *****************
 # Kernel-Audit

--- a/config-templates/id-authentication-env.properties
+++ b/config-templates/id-authentication-env.properties
@@ -220,12 +220,6 @@ id-masterdata-title-service.rest.httpMethod=GET
 id-masterdata-title-service.rest.headers.mediaType=${mosip.ida.request.mediaType}
 id-masterdata-title-service.rest.timeout=${mosip.ida.request.timeout.secs}
 
-# TokeId Generator rest api-GET
-token-id-generator.rest.uri=${mosip.base.url}/v1/tokenidgenerator/{uin}/{partnercode}
-token-id-generator.rest.httpMethod=GET
-token-id-generator.rest.headers.mediaType=${mosip.ida.request.mediaType}
-token-id-generator.rest.timeout=${mosip.ida.request.timeout.secs}
-
 #Auth token
 auth-token-generator.rest.uri=${mosip.base.url}/v1/authmanager/authenticate/clientidsecretkey
 auth-token-validator.rest.uri=${mosip.base.url}/v1/authmanager/authorize/validateToken


### PR DESCRIPTION
As kernel tokenIdgenerator service is used as a library. So following configuration keys are not required.
# TokeId Generator rest api-GET
token-id-generator.rest.uri=${mosip.base.url}/v1/tokenidgenerator/{uin}/{partnercode}
token-id-generator.rest.httpMethod=GET
token-id-generator.rest.headers.mediaType=${mosip.ida.request.mediaType}
token-id-generator.rest.timeout=${mosip.ida.request.timeout.secs}

Added following keys
mosip.kernel.tokenid.uin.salt=zHuDEAbmbxiUbUShgy6pwUhKh9DE0EZn9kQDKPPKbWscGajMwf
mosip.kernel.tokenid.partnercode.salt=yS8w5Wb6vhIKdf1msi4LYTJks7mqkbmITk2O63Iq8h0bkRlD0d